### PR TITLE
👽 Add google repo in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,6 @@
 buildscript {
   repositories {
+    google()
     jcenter()
   }
 


### PR DESCRIPTION
Fix android studio 3.6 throwing error when syncing gradle